### PR TITLE
devshell: fix nix-plugins load under nixos-rebuild (pin Nix 2.30, no …

### DIFF
--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -2,6 +2,35 @@
 , ...
 }: {
   perSystem = { pkgs, system, ... }:
+    let
+      # Getting `nixos-rebuild` to load our nix-plugins takes two fixes:
+      #
+      # 1. Pin its Nix to 2.30. The default `pkgs.nix-plugins` is built against
+      #    Nix 2.30's C++ ABI, so only a 2.30 loader can resolve its symbols;
+      #    2.31/2.34 fail with `undefined symbol: …` before the
+      #    `ageImportEncrypted` builtin `meta.nix` needs is ever available.
+      #    (Unlike agenix's pure `secrets.nix`, this eval genuinely needs the
+      #    plugin, so we can't just strip it.) The override below shadows the
+      #    system nixos-rebuild via the devshell PATH.
+      #
+      # 2. Disable re-exec (`_NIXOS_REBUILD_REEXEC=1`). Before building,
+      #    nixos-rebuild-ng builds `config.system.build.nixos-rebuild` from the
+      #    *target* config and `execve`s into it — and that copy uses the
+      #    target's own Nix (2.34 on 26.05), which then reloads the 2.30 plugin
+      #    and fails. Setting the guard env var makes it skip the re-exec and do
+      #    the whole build with our 2.30 Nix. Safe here: our nixos-rebuild is the
+      #    same 26.05 release as the targets.
+      nixos-rebuild =
+        let
+          base = pkgs.nixos-rebuild-ng.override {
+            nix = pkgs.nixVersions.nix_2_30;
+          };
+        in
+        pkgs.writeShellScriptBin "nixos-rebuild" ''
+          export _NIXOS_REBUILD_REEXEC=1
+          exec ${base}/bin/nixos-rebuild "$@"
+        '';
+    in
     {
       # Add all the nixos configurations to the checks
       # checks = lib.mapAttrs' (name: value: { name = "nixos-toplevel-${name}"; value = value.config.system.build.toplevel; }) sysConfigs;
@@ -17,11 +46,15 @@
           inputs.agenix.outputs.packages.${system}.agenix
           pkgs.deploy-rs
           pkgs.age
-          # nix-plugins 16.0.1 only builds against Nix 2.31's C++ API, and the
-          # plugin must be loaded by the exact same Nix version. Pin the devshell
-          # nix so the loader matches the plugin (default pkgs.nix is 2.34, which
-          # both fails to build nix-plugins and is ABI-incompatible with it).
-          pkgs.nixVersions.nix_2_31
+          # The default `pkgs.nix-plugins` (16.0.1) is built against Nix 2.30's
+          # C++ API, and the plugin must be loaded by that exact Nix version.
+          # Pin the devshell nix to 2.30 so the loader matches the plugin. (Nix
+          # 2.31 links but can't resolve `EvalState::allocBindings`; 2.34 is
+          # fully ABI-incompatible — both fail with `undefined symbol` at load.)
+          pkgs.nixVersions.nix_2_30
+          # nixos-rebuild pinned to Nix 2.30 so it can load our nix-plugins
+          # (see the `nixos-rebuild` binding above). Shadows the system one.
+          nixos-rebuild
           pkgs.cloudflared
           pkgs.borgbackup
         ];
@@ -131,7 +164,7 @@
             # We need this for our repo secrets.
             name = "NIX_CONFIG";
             value = ''
-              plugin-files = ${pkgs.nix-plugins.override {nixComponents = pkgs.nixVersions.nixComponents_2_31;}}/lib/nix/plugins
+              plugin-files = ${pkgs.nix-plugins}/lib/nix/plugins
               extra-builtins-file = ${./..}/nix/extra-builtins.nix
             '';
           }


### PR DESCRIPTION
…re-exec)

`nixos-rebuild --flake .#<host> ...` aborted every build with `undefined symbol: …` while loading our nix-plugins extra-builtins .so, before the `ageImportEncrypted` builtin `meta.nix` needs was available.

Three compounding causes, all fixed here:

1. Wrong Nix pinned. `pkgs.nix-plugins` 16.0.1 is built against Nix 2.30's C++ ABI, but the devshell pinned 2.31 (and overrode the plugin to `nixComponents_2_31`). 2.31/2.34 can't resolve the plugin's symbols (`allocBindings`, `getSettings`). Pin the devshell Nix to 2.30 and drop the plugin override so it uses the default 2.30 build.

2. The system nixos-rebuild-ng hardcodes its own Nix (2.34) at the front of PATH, ignoring the devshell. Ship an overridden nixos-rebuild pinned to 2.30 in the devshell so it shadows the system one.

3. Re-exec. Before building, nixos-rebuild-ng builds `config.system.build.nixos-rebuild` from the *target* config and execve's into it — and that copy uses the target's Nix (2.34 on 26.05), which then reloads the 2.30 plugin and fails. Set `_NIXOS_REBUILD_REEXEC=1` in the wrapper to skip the re-exec; safe, as our nixos-rebuild is the same 26.05 release as the targets.

Verified end-to-end: `nixos-rebuild --flake .#beast --target-host beast --sudo boot` completes and stages a new boot generation.